### PR TITLE
Upgrade Node to version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,5 +48,5 @@ outputs:
   pull_request:
     description: 'If this workflow is running on a pull request or not.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Fix for: `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Dovyski/payload-info-action@master`